### PR TITLE
Add an explicit test for patterns of the type mentioned in issue #1

### DIFF
--- a/test.js
+++ b/test.js
@@ -118,6 +118,8 @@ describe('isExtglob', function () {
     assert(!isExtglob('aa'));
     assert(!isExtglob('abc.js'));
     assert(!isExtglob('abc/def/ghi.js'));
+    assert(!isExtglob('[a@(x)]'));
+    assert(!isExtglob('xyz/[a@(x)]/xyz'));
   });
 });
 


### PR DESCRIPTION
Sorry to belabor the point, but I feel I must have been unclear in my explanation of the problem I perceive. (in issue #1)

I believe the following additions to the test suite are correct, but they currently fail since the logic in is-extglob is insufficient:

```
$ npm test

> is-extglob@2.0.0 test /home/jepler/src/is-extglob
> mocha



  isExtglob
    ✓ should return true when the string has an extglob:
    ✓ should not match escaped extglobs
    ✓ should detect when an extglob is in the same pattern as an escaped extglob
    1) should return false when the string does not have an extglob:


  3 passing (8ms)
  1 failing

  1) isExtglob should return false when the string does not have an extglob::

      AssertionError: false == true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (test.js:121:5)
```

I confused the issue by also talking about the difficulty of correctly recognizing these square-bracket-delimited things (which may be more correctly called a "pattern bracket expression", http://pubs.opengroup.org/onlinepubs/007904875/utilities/xcu_chap02.html#tag_02_13_01).

If we continue to disagree about this point, I will drop the matter.  In either case, thank you for your time.
